### PR TITLE
修改config.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ cookie=""
 
 headers = {
         "Connection": "keep-alive",
-        "cookie": cookie
+        "cookie": cookie.encode("utf-8").decode("latin1")
     }
 
 SearchKEY=""


### PR DESCRIPTION
request请求参数中(如cookie)包含中文可能诱发报错  UnicodeEncodeError: 'latin-1' codec can't encode characters \uXXXX in position,解决办法是   '你的字符串'.encode("utf-8").decode("latin1")